### PR TITLE
Underline bug on iOS

### DIFF
--- a/ScrollableTabs.js
+++ b/ScrollableTabs.js
@@ -48,6 +48,9 @@ class ScrollableTabs extends React.Component{
     }
 
     _updateView(offset) {
+        if (offset.value === undefined) {
+            offset.value = 0;
+        }
         const position = Math.floor(offset.value);
         const pageOffset = offset.value % 1;
         const tabCount = this.props.tabs.length;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-scrollable-tab-header",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Separate tab header component which gives you relevant callbacks to build your own tab implementation",
   "main": "index.js",
   "dependencies": {},


### PR DESCRIPTION
Offset value comes as null initially. Treating it as zero.