### PR TITLE
React native migration to version 0.59.8

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -135,7 +135,7 @@ export interface DefaultTabBarProps {
     textStyle?: RegisteredStyle<ViewStyle | TextStyle | ImageStyle>;
     tabStyle?: RegisteredStyle<ViewStyle | TextStyle | ImageStyle>;
     renderTab?: RenderTabProperties;
-    underlineStyle?: RegisteredStyle<ViewStyle | TextStyle | ImageStyle>;
+    underlineStyle?: StyleProp<ViewStyle | TextStyle | ImageStyle>;
     contentContainerStyle?: RegisteredStyle<ViewStyle | TextStyle | ImageStyle>;
 }
 
@@ -147,7 +147,7 @@ export class DefaultTabBar extends React.Component<TabBarProps<DefaultTabBarProp
 
 export interface ScrollableTabBarProps extends DefaultTabBarProps {
     scrollOffset?: number;
-    style: RegisteredStyle<ViewStyle | TextStyle | ImageStyle>;
+    style: StyleProp<ViewStyle | TextStyle | ImageStyle>;
     tabsContainerStyle?: ViewStyle;
 }
 


### PR DESCRIPTION
Changes to resolve type script errors reported during react native migration (version 0.59.8)

Following is the snapshot of errors reported. The type mismatch had to be resolved by using the exact type **StyleProp** instead of **RegisteredStyle**

![Screenshot 2019-05-31 at 10 32 02 AM](https://user-images.githubusercontent.com/6612035/58783076-abf9b680-85fd-11e9-9566-1b245bfe8f42.png)
