### PR TITLE
updating the export statement in index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,2 @@
-module.exports = require('./ScrollableTabs');
+import ScrollableTabs from './ScrollableTabs';
+export default ScrollableTabs;


### PR DESCRIPTION
While importing and rendering `ScrollableTabs` I was getting the following error
`Uncaught Invariant Violation: Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: object.`

While debugging, @muskeinsingh and I found that the problem was with `require('./ScrollableTabs')`.
`require` is importing the default `ScrollableTabs` inside an object like
```
{
  default: ScrollableTabs
}
```
instead of a direct import but `module.exports` was expecting a default export that is why the error `got an object instead of a class/function`.

Now, as @muskeinsingh suggested, we are using `import/export` statements to resolve the default import conflict.